### PR TITLE
Enables dropdown query types for RPC, CONSTS, etc.

### DIFF
--- a/polkadot/state.html
+++ b/polkadot/state.html
@@ -5,13 +5,16 @@
         defaults: {
             name: {value: ""},
             client: {value: "", type: "client", required: true},
+            qtype: {value: "query", required: false},
             method: {value: "timestamp.now()", required: false}
         },
         inputs: 1,
         outputs: 1,
         icon: "font-awesome/fa-hdd-o",
         label: function () {
-            return this.name || this.method.substring(0, this.method.indexOf('(')) || "query state";
+            let full_method;
+            if (this.method && this.qtype) full_method=`${this.qtype}.${this.method.substring(0, this.method.indexOf('('))}`
+            return this.name || full_method || "query api";
         }
     });
 </script>
@@ -26,11 +29,20 @@
         <input type="text" id="node-input-client" placeholder="Client">
     </div>
     <div class="form-row">
+        <label for="node-input-qtype"><i class="fa fa-cogs"></i> Query Type</label>
+        <select id="node-input-qtype">
+            <option value="query">query</option>
+            <option value="rpc">rpc</option>
+            <option value="consts">consts</option>
+            <option value="">{ msg.qtype }</option>
+        </select>
+    </div>
+    <div class="form-row">
         <label for="node-input-method"><i class="fa fa-tag"></i> Method</label>
         <input type="text" id="node-input-method" placeholder="Method (or msg.method)">
     </div>
 </script>
 
 <script type="text/html" data-help-name="query state">
-    <p>Query storage at a given pallet / method</p>
+    <p>Query polkadot api at a given pallet / method</p>
 </script>

--- a/polkadot/state.html
+++ b/polkadot/state.html
@@ -31,10 +31,10 @@
     <div class="form-row">
         <label for="node-input-qtype"><i class="fa fa-cogs"></i> Query Type</label>
         <select id="node-input-qtype">
-            <option value="query">query</option>
-            <option value="rpc">rpc</option>
-            <option value="consts">consts</option>
-            <option value="">{ msg.qtype }</option>
+            <option value="query">api.query</option>
+            <option value="rpc">api.rpc</option>
+            <option value="consts">api.consts</option>
+            <option value="">api.{ msg.qtype }</option>
         </select>
     </div>
     <div class="form-row">

--- a/polkadot/state.html
+++ b/polkadot/state.html
@@ -34,7 +34,7 @@
             <option value="query">api.query</option>
             <option value="rpc">api.rpc</option>
             <option value="consts">api.consts</option>
-            <option value="">api.{ msg.qtype }</option>
+            <option value="$">api.{ msg.qtype }</option>
         </select>
     </div>
     <div class="form-row">

--- a/polkadot/state.js
+++ b/polkadot/state.js
@@ -4,17 +4,30 @@ module.exports = function (RED) {
         const node = this;
         node.client = RED.nodes.getNode(config.client);
         node.on('input', async function (msg) {
+
+            // Migration of flows from 0.0.11 and older version required.
+            // If query type is missing in configuration must be set to historic default
+            if(config.qtype == undefined){
+                config.qtype="query";
+                node.warn('Query Type missing, using defaulting to "query"')
+            }
+
             node.status({fill: "yellow", shape: "dot", text: "connecting"});
             const client = await node.client.connect();
             if (client == null) {
                 node.status({fill: "red", shape: "dot", text: "disconnected"});
             } else {
+
                 const api = client.api
                 const method = "method" in msg ? msg.method : config.method;
                 const qtype = "qtype" in msg ? msg.qtype : config.qtype;
 
                 node.status({fill: "green", shape: "dot", text: "connected"});
                 try {
+                    // Check if message was received as expected
+                    if (qtype === "$") throw "msg.qtype was undefined";
+                    if (method === "") throw "msg.method was undefined";
+
                     // Exec
                     const [result] = await Promise.all([
                         eval(`api.${qtype}.${method}`),

--- a/polkadot/state.js
+++ b/polkadot/state.js
@@ -9,7 +9,7 @@ module.exports = function (RED) {
             // If query type is missing in configuration must be set to historic default
             if(config.qtype == undefined){
                 config.qtype="query";
-                node.warn('Query Type missing, using defaulting to "query"')
+                node.warn('Query Type missing, using default "query", please configure the node')
             }
 
             node.status({fill: "yellow", shape: "dot", text: "connecting"});

--- a/polkadot/state.js
+++ b/polkadot/state.js
@@ -11,11 +11,13 @@ module.exports = function (RED) {
             } else {
                 const api = client.api
                 const method = "method" in msg ? msg.method : config.method;
+                const qtype = "qtype" in msg ? msg.qtype : config.qtype;
+
                 node.status({fill: "green", shape: "dot", text: "connected"});
                 try {
                     // Exec
                     const [result] = await Promise.all([
-                        eval(`api.query.${method}`),
+                        eval(`api.${qtype}.${method}`),
                     ]);
                     msg.payload = JSON.parse(JSON.stringify(result));
                     // Done


### PR DESCRIPTION
Have a look, it allows for setting a query type.

It would be nice to rename from query state to a more generic query api, but I don't think it is possible or matters that much.

I am going to be testing a bit more, wait for my signal to merge.

Here is the test flow I am using, in case you also want to test:

```
[
    {
        "id": "c19ba37127e3efd6",
        "type": "query state",
        "z": "5a89f275502f4b5a",
        "name": "Test",
        "client": "4d7e2a1e67067c32",
        "qtype": "rpc",
        "method": "system.version()",
        "x": 470,
        "y": 200,
        "wires": [
            [
                "798e65212ce0967b"
            ]
        ]
    },
    {
        "id": "798e65212ce0967b",
        "type": "debug",
        "z": "5a89f275502f4b5a",
        "name": "debug 1",
        "active": true,
        "tosidebar": true,
        "console": false,
        "tostatus": false,
        "complete": "false",
        "statusVal": "",
        "statusType": "auto",
        "x": 920,
        "y": 280,
        "wires": []
    },
    {
        "id": "4fe74118094b7160",
        "type": "inject",
        "z": "5a89f275502f4b5a",
        "name": "Static Query",
        "props": [
            {
                "p": "now",
                "v": "",
                "vt": "date"
            }
        ],
        "repeat": "",
        "crontab": "",
        "once": false,
        "onceDelay": 0.1,
        "topic": "",
        "x": 150,
        "y": 300,
        "wires": [
            [
                "c19ba37127e3efd6",
                "834efa4fe1949635",
                "7a96843867e4dafe"
            ]
        ]
    },
    {
        "id": "834efa4fe1949635",
        "type": "query state",
        "z": "5a89f275502f4b5a",
        "name": "",
        "client": "4d7e2a1e67067c32",
        "qtype": "query",
        "method": "timestamp.now()",
        "x": 520,
        "y": 300,
        "wires": [
            [
                "798e65212ce0967b"
            ]
        ]
    },
    {
        "id": "7a96843867e4dafe",
        "type": "query state",
        "z": "5a89f275502f4b5a",
        "name": "",
        "client": "4d7e2a1e67067c32",
        "qtype": "consts",
        "method": "babe.epochDuration.toNumber()",
        "x": 570,
        "y": 380,
        "wires": [
            [
                "798e65212ce0967b"
            ]
        ]
    },
    {
        "id": "011c9452d9ac8318",
        "type": "query state",
        "z": "5a89f275502f4b5a",
        "name": "",
        "client": "4d7e2a1e67067c32",
        "qtype": "",
        "method": "",
        "x": 470,
        "y": 640,
        "wires": [
            [
                "a5325e49323317c1"
            ]
        ]
    },
    {
        "id": "95e3f437b0858b21",
        "type": "inject",
        "z": "5a89f275502f4b5a",
        "name": "Dynamic Query",
        "props": [
            {
                "p": "qtype",
                "v": "query",
                "vt": "str"
            },
            {
                "p": "method",
                "v": "timestamp.now()",
                "vt": "str"
            }
        ],
        "repeat": "",
        "crontab": "",
        "once": false,
        "onceDelay": 0.1,
        "topic": "",
        "x": 180,
        "y": 640,
        "wires": [
            [
                "011c9452d9ac8318"
            ]
        ]
    },
    {
        "id": "a5325e49323317c1",
        "type": "debug",
        "z": "5a89f275502f4b5a",
        "name": "debug 2",
        "active": true,
        "tosidebar": true,
        "console": false,
        "tostatus": false,
        "complete": "false",
        "statusVal": "",
        "statusType": "auto",
        "x": 900,
        "y": 640,
        "wires": []
    },
    {
        "id": "4d7e2a1e67067c32",
        "type": "client",
        "name": "Polkadot IO",
        "endpoint": "wss://rpc.polkadot.io/",
        "keytype": "sr25519"
    }
]
```
